### PR TITLE
修复 API 调用频繁 403：伪装真实客户端 User-Agent + 退避重试 + 可读错误信息

### DIFF
--- a/enrollment.py
+++ b/enrollment.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import json
 import math
+import os
+import random
 import re
 import secrets
+import time
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -18,6 +21,25 @@ from challenge_suite import fingerprint_suite
 PROJECT = Path(__file__).resolve().parent
 DATA_FILE = PROJECT / "data" / "gpt_reference.jsonl"
 BANK_FILE = PROJECT / "data" / "gpt_bank.json"
+
+# urllib 默认的 Python-urllib User-Agent 会被 Cloudflare/WAF 网关直接拦成 403，
+# 因此伪装成真实客户端（与 gpt56 检测器使用的 UA 一致）。
+DEFAULT_UPSTREAM_USER_AGENT = (
+    "Codex Desktop/0.147.0-alpha.1.2 (Windows 10.0.26200; x86_64) unknown "
+    "(codex_exec; 0.147.0-alpha.1.2)"
+)
+RETRYABLE_STATUS = {408, 429, 500, 502, 503, 504}
+MAX_ATTEMPTS = 3
+RETRY_BASE_DELAY = 1.0
+
+
+def upstream_user_agent() -> str:
+    override = (
+        os.environ.get("MODELTRACE_USER_AGENT")
+        or os.environ.get("GPT56_USER_AGENT")
+        or ""
+    ).strip()
+    return override or DEFAULT_UPSTREAM_USER_AGENT
 
 
 def bank_summary(bank: dict) -> dict:
@@ -147,6 +169,40 @@ def completion_url(base_url: str, api_format: str = "openai") -> str:
     return normalized + "/v1/chat/completions"
 
 
+def _looks_like_waf_block(text: str) -> bool:
+    lowered = text.lower()
+    return any(
+        marker in lowered
+        for marker in ("cloudflare", "just a moment", "cf-ray", "access denied", "attention required")
+    )
+
+
+def _compact_upstream_error(details: str, fallback: str) -> str:
+    text = (details or fallback or "").strip()
+    if not text:
+        return "上游接口返回错误"
+    if _looks_like_waf_block(text):
+        return (
+            "请求被上游网关拦截（Cloudflare/WAF 拦截页）。"
+            "请确认 base_url 指向 API 端点而非网页地址、API Key 有效，"
+            "或该服务是否限制当前网络/IP"
+        )
+    if text.startswith("<") or "{" not in text and "html" in text.lower():
+        return text[:200]
+    try:
+        payload = json.loads(text)
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict):
+                return str(error.get("message") or error)
+            if error:
+                return str(error)
+            return json.dumps(payload, ensure_ascii=False)[:500]
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+    return text[:500]
+
+
 def _request_completion(
     base_url: str,
     api_key: str,
@@ -169,6 +225,8 @@ def _request_completion(
             "Authorization": f"Bearer {api_key}",
             "anthropic-version": "2023-06-01",
             "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": upstream_user_agent(),
         }
     else:
         body_data = {
@@ -181,22 +239,35 @@ def _request_completion(
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": upstream_user_agent(),
         }
     if temperature is not None:
         body_data["temperature"] = temperature
     body = json.dumps(body_data).encode("utf-8")
-    request = urllib.request.Request(
-        completion_url(base_url, api_format),
-        data=body,
-        headers=headers,
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=240) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as error:
-        details = error.read().decode("utf-8", errors="replace").strip()
-        raise RuntimeError(f"HTTP {error.code}: {details or error.reason}") from error
+    url = completion_url(base_url, api_format)
+    payload = None
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        request = urllib.request.Request(url, data=body, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(request, timeout=240) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            break
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace").strip()
+            message = _compact_upstream_error(details, error.reason)
+            retried = f"（已自动重试 {attempt - 1} 次）" if attempt > 1 else ""
+            if attempt < MAX_ATTEMPTS and error.code in RETRYABLE_STATUS:
+                time.sleep(RETRY_BASE_DELAY * attempt + random.uniform(0, 0.5))
+                continue
+            raise RuntimeError(f"HTTP {error.code}: {message}{retried}") from error
+        except urllib.error.URLError as error:
+            reason = getattr(error, "reason", str(error))
+            if attempt < MAX_ATTEMPTS:
+                time.sleep(RETRY_BASE_DELAY * attempt + random.uniform(0, 0.5))
+                continue
+            retried = f"（已自动重试 {attempt - 1} 次）" if attempt > 1 else ""
+            raise RuntimeError(f"无法连接接口：{reason}{retried}") from error
     if api_format == "anthropic":
         content = "".join(
             block.get("text", "")


### PR DESCRIPTION
## 问题

通过 API 自动测试 / 自动建库调用第三方接口时，上游经常返回 **403**，导致探测失败。日志中表现为 `POST /api/test/probe` 连续 403。

## 根因

`enrollment.py` 使用 `urllib` 发请求，未设置 `User-Agent`，默认值为 `Python-urllib/3.x`。该特征会被 Cloudflare 等 WAF 网关直接拦截并返回 403，与 API Key 是否有效无关。

对照验证：使用真实客户端 User-Agent 的同类工具请求相同接口不会 403。

## 改动（仅 `enrollment.py`）

1. **真实客户端 User-Agent**：OpenAI / Anthropic 两种请求均携带真实客户端 UA 与 `Accept: application/json`，不再暴露 `Python-urllib` 特征；可用环境变量 `MODELTRACE_USER_AGENT` / `GPT56_USER_AGENT` 覆盖。
2. **退避重试**：408/429/500/502/503/504 及网络连接错误自动重试（最多 2 次，间隔约 1s/2s + 抖动）；403/401 等客户端错误快速失败不重试。
3. **可读错误信息**：新增 `_compact_upstream_error`——Cloudflare/WAF 拦截页识别为明确中文提示；JSON 错误只提取上游 `message`；不再把整页 HTML 原样塞进错误信息。

## 验证

本地 mock 服务器测试全部通过：

- [x] 请求 UA 为真实客户端 UA，不再是 `Python-urllib`
- [x] 连续两次 429 后第三次成功（自动重试生效）
- [x] 403 WAF 拦截页：单次尝试即返回明确中文提示，不重试
- [x] 401 JSON 错误：准确显示上游错误消息（如 `Incorrect API key provided`）
- [x] OpenAI "/v1/chat/completions" 与 Anthropic "/v1/messages" 路径均正常
- [x] Flask 应用正常启动，`/` 与 `/api/challenges` 返回 200